### PR TITLE
Convert images to RGB mode before display

### DIFF
--- a/pyiron_gui/project/project_browser.py
+++ b/pyiron_gui/project/project_browser.py
@@ -560,6 +560,7 @@ class DisplayOutputGUI:
             try:
                 data_cp = obj.copy()
                 data_cp.thumbnail((800, 800))
+                data_cp = data_cp.convert('RGB')
             except:
                 data_cp = obj
             return data_cp


### PR DESCRIPTION
Images in the 'CMYK' mode can't be saved to `png` which is usually done for `display`. Thus, in addition to make a (800x800) thumbnail for performance reasons, I also convert to 'RGB' color scheme now. This only affects the displayed image in the browser, not the actual image data accessible via the data attribute of the ProjectBrowser.